### PR TITLE
Append a missing closing parenthesis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ansible jetbrains toolbox role
 ==============================
 
-![CI](https://github.com/baztian/ansible-jetbrains-toolbox/workflows/CI/badge.svg
+![CI](https://github.com/baztian/ansible-jetbrains-toolbox/workflows/CI/badge.svg)
 
 Role to download, install and setup git plus associated tools.
 


### PR DESCRIPTION
This fixes the CI badge in README.md.

Thank you for creating this useful playbook!